### PR TITLE
投票日以前にアクセスしたユーザーのクッキーをリセットする条件文を追加しました。

### DIFF
--- a/teens_ui/src/App.vue
+++ b/teens_ui/src/App.vue
@@ -28,11 +28,15 @@ export default {
     document.querySelector("meta[property='og:description']").setAttribute('content', description)
   },
   created() {
-    // クッキーが存在しないか、クッキーが生成されてから一日あるいは二日経過している場合。
-    if (!(VueCookies.isKey('teens_vote_date'))
-    || ((new Date(VueCookies.get('teens_vote_date')).getDate() === 8) && (new Date().getDate() === 9))
-    || ((new Date(VueCookies.get('teens_vote_date')).getDate() === 8) && (new Date().getDate() === 10))
-    || ((new Date(VueCookies.get('teens_vote_date')).getDate() === 9) && (new Date().getDate() === 10))) {
+    let teens_vote_date = new Date(VueCookies.get('teens_vote_date'))
+    if (!(VueCookies.isKey('teens_vote_date')) // クッキーが存在しないか
+    || (teens_vote_date.getMonth() === 10) // 投票日以前にアクセスしていた場合クッキーを更新
+    || (teens_vote_date.getMonth() === 11) // 投票日以前にアクセスしていた場合クッキーを更新
+    || ((teens_vote_date.getMonth() === 0) && (0 <= teens_vote_date.getDate()) && (teens_vote_date.getDate() <= 7)) // 投票日以前にアクセスしていた場合クッキーを更新
+    || ((teens_vote_date.getMonth() === 0) && (teens_vote_date.getDate() === 8) && (new Date().getDate() === 9)) // クッキーが生成されてから一日あるいは二日経過している場合
+    || ((teens_vote_date.getMonth() === 0) && (teens_vote_date.getDate() === 8) && (new Date().getDate() === 10))  // クッキーが生成されてから一日あるいは二日経過している場合
+    || ((teens_vote_date.getMonth() === 0) && (teens_vote_date.getDate() === 9) && (new Date().getDate() === 10))) // クッキーが生成されてから一日あるいは二日経過している場合
+    {
       VueCookies.set('teens_vote_date', new Date().toLocaleString({ timeZone: 'Asia/Tokyo' })); // クッキーが生成された日時を日本標準時間で保存する
       VueCookies.set('teens_if_voted', false);
       VueCookies.set('teens_user_agent', navigator.userAgent);

--- a/teens_ui/src/components/teens/Modal.vue
+++ b/teens_ui/src/components/teens/Modal.vue
@@ -158,7 +158,8 @@
       check_if_voting_period () {
         let vote_date = VueCookies.get('teens_vote_date');
         if ((new Date("2022-01-07T15:00:00Z") <= new Date(vote_date))
-        && (new Date(vote_date) <= new Date("2022-01-10T11:00:00Z"))) { // 日本時間で投票期間であるかのチェック
+        && (new Date(vote_date) <= new Date("2022-01-10T11:00:00Z"))) // アクセス地域の時間で投票期間であるかのチェック
+        {
           return true;
         } else {
           return false

--- a/teens_ui/src/components/teens/Vote.vue
+++ b/teens_ui/src/components/teens/Vote.vue
@@ -167,11 +167,15 @@
     },
     methods: {
       openModal (item) {
-        // クッキーが存在しないか、クッキーが生成されてから一日あるいは二日経過している場合。
-        if (!(VueCookies.isKey('teens_vote_date'))
-        || ((new Date(VueCookies.get('teens_vote_date')).getDate() === 8) && (new Date().getDate() === 9))
-        || ((new Date(VueCookies.get('teens_vote_date')).getDate() === 8) && (new Date().getDate() === 10))
-        || ((new Date(VueCookies.get('teens_vote_date')).getDate() === 9) && (new Date().getDate() === 10))) {
+        let teens_vote_date = new Date(VueCookies.get('teens_vote_date'))
+        if (!(VueCookies.isKey('teens_vote_date')) // クッキーが存在しないか
+        || (teens_vote_date.getMonth() === 10) // 投票日以前にアクセスしていた場合クッキーを更新
+        || (teens_vote_date.getMonth() === 11) // 投票日以前にアクセスしていた場合クッキーを更新
+        || ((teens_vote_date.getMonth() === 0) && (0 <= teens_vote_date.getDate()) && (teens_vote_date.getDate() <= 7)) // 投票日以前にアクセスしていた場合クッキーを更新
+        || ((teens_vote_date.getMonth() === 0) && (teens_vote_date.getDate() === 8) && (new Date().getDate() === 9)) // クッキーが生成されてから一日あるいは二日経過している場合
+        || ((teens_vote_date.getMonth() === 0) && (teens_vote_date.getDate() === 8) && (new Date().getDate() === 10)) // クッキーが生成されてから一日あるいは二日経過している場合
+        || ((teens_vote_date.getMonth() === 0) && (teens_vote_date.getDate() === 9) && (new Date().getDate() === 10))) // クッキーが生成されてから一日あるいは二日経過している場合
+        {
           VueCookies.set('teens_vote_date', new Date().toLocaleString({ timeZone: 'Asia/Tokyo' })); // クッキーが生成された日時を日本標準時間で保存する
           VueCookies.set('teens_if_voted', false);
           VueCookies.set('teens_user_agent', navigator.userAgent);

--- a/youth_ui/src/App.vue
+++ b/youth_ui/src/App.vue
@@ -38,11 +38,15 @@ export default {
     document.querySelector("meta[property='og:description']").setAttribute('content', description)
   },
   created() {
-    // クッキーが存在しないか、クッキーが生成されてから一日あるいは二日経過している場合。
-    if (!(VueCookies.isKey('youth_vote_date'))
-    || ((new Date(VueCookies.get('youth_vote_date')).getDate() === 8) && (new Date().getDate() === 9)) 
-    || ((new Date(VueCookies.get('youth_vote_date')).getDate() === 8) && (new Date().getDate() === 10)) 
-    || ((new Date(VueCookies.get('youth_vote_date')).getDate() === 9) && (new Date().getDate() === 10))) {
+    let youth_vote_date = new Date(VueCookies.get('youth_vote_date'))
+    if (!(VueCookies.isKey('youth_vote_date')) // クッキーが存在しないか
+    || (youth_vote_date.getMonth() === 10) // 投票日以前にアクセスしていた場合クッキーを更新
+    || (youth_vote_date.getMonth() === 11) // 投票日以前にアクセスしていた場合クッキーを更新
+    || ((youth_vote_date.getMonth() === 0) && (0 <= youth_vote_date.getDate()) && (youth_vote_date.getDate() <= 7)) // 投票日以前にアクセスしていた場合クッキーを更新
+    || ((youth_vote_date.getMonth() === 0) && (youth_vote_date.getDate() === 8) && (new Date().getDate() === 9)) // クッキーが生成されてから一日あるいは二日経過している場合
+    || ((youth_vote_date.getMonth() === 0) && (youth_vote_date.getDate() === 8) && (new Date().getDate() === 10)) // クッキーが生成されてから一日あるいは二日経過している場合
+    || ((youth_vote_date.getDate() === 9) && (new Date().getDate() === 10))) // クッキーが生成されてから一日あるいは二日経過している場合
+    {
       VueCookies.set('youth_vote_date', new Date().toLocaleString({ timeZone: 'Asia/Tokyo' })); // クッキーが生成された日時を日本標準時間で保存する
       VueCookies.set('youth_if_voted', false);
       VueCookies.set('youth_user_agent', navigator.userAgent);

--- a/youth_ui/src/components/youth/Modal.vue
+++ b/youth_ui/src/components/youth/Modal.vue
@@ -157,7 +157,8 @@
       check_if_voting_period () {
         let vote_date = VueCookies.get('youth_vote_date');
         if ((new Date("2022-01-07T15:00:00Z") <= new Date(vote_date))
-        && (new Date(vote_date) <= new Date("2022-01-10T11:00:00Z"))) { // 日本時間で投票期間であるかのチェック
+        && (new Date(vote_date) <= new Date("2022-01-10T11:00:00Z"))) // アクセス地域の時間で投票期間であるかのチェック
+        {
           return true;
         } else {
           return false;

--- a/youth_ui/src/components/youth/Vote.vue
+++ b/youth_ui/src/components/youth/Vote.vue
@@ -190,11 +190,15 @@
     },
     methods: {
       openModal (item) {
-        // クッキーが存在しないか、クッキーが生成されてから一日あるいは二日経過している場合。
-        if (!(VueCookies.isKey('youth_vote_date'))
-        || ((new Date(VueCookies.get('youth_vote_date')).getDate() === 8) && (new Date().getDate() === 9))
-        || ((new Date(VueCookies.get('youth_vote_date')).getDate() === 8) && (new Date().getDate() === 10))
-        || ((new Date(VueCookies.get('youth_vote_date')).getDate() === 9) && (new Date().getDate() === 10))) {
+        let youth_vote_date = new Date(VueCookies.get('youth_vote_date'))
+        if (!(VueCookies.isKey('youth_vote_date')) // クッキーが存在しないか
+        || (youth_vote_date.getMonth() === 10) // 投票日以前にアクセスしていた場合クッキーを更新
+        || (youth_vote_date.getMonth() === 11) // 投票日以前にアクセスしていた場合クッキーを更新
+        || ((youth_vote_date.getMonth() === 0) && (0 <= youth_vote_date.getDate()) && (youth_vote_date.getDate() <= 7)) // 投票日以前にアクセスしていた場合クッキーを更新
+        || ((youth_vote_date.getMonth() === 0) && (youth_vote_date.getDate() === 8) && (new Date().getDate() === 9)) // クッキーが生成されてから一日あるいは二日経過している場合
+        || ((youth_vote_date.getMonth() === 0) && (youth_vote_date.getDate() === 8) && (new Date().getDate() === 10)) // クッキーが生成されてから一日あるいは二日経過している場合
+        || ((youth_vote_date.getDate() === 9) && (new Date().getDate() === 10))) // クッキーが生成されてから一日あるいは二日経過している場合
+        {
           VueCookies.set('youth_if_voted', false);
           VueCookies.set('youth_user_agent', navigator.userAgent);
         }


### PR DESCRIPTION
https://github.com/YSP-SINERGY/xserver-sinergy2021-event-website/issues/36
こちらのイシューにて共有させていただいている内容で、
恐らく、投票日以前にアクセスした際のクッキーが残って投票ができずにいるのではないかと思い、
投票日以前にアクセスした際のクッキーをリセットする条件文を追加しました。